### PR TITLE
Minor fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,11 +7,11 @@
 }
 
 .co-icon-wrapper.disabled {
-    color:red;
+    color: #F74687;
 }
 
 .co-icon-wrapper.enabled {
-    color:greed;
+    color: #91CC41;
 }
 
 .code-overview-wrapper {
@@ -27,9 +27,9 @@
     display: none;
 }
 
-.code-overview-wrapper .CodeMirror-cursor {
-/*    display: none !important;*/
-}
+/*.code-overview-wrapper .CodeMirror-cursor {
+    display: none !important;
+}*/
 
 .code-overview-content-wrapper {
     height: 100%;


### PR DESCRIPTION
- Use proper Extension colors, per [guidelines](https://github.com/adobe/brackets/wiki/Extension-Icon-Guidelines#use-colors-to-indicate-extension-state)
- Fix invalid `color` value in `.co-icon-wrapper.enabled` rule. It has read `greed` since the CSS was added.
- Fix CSSLint empty rule warning

Personally, I'm not too sure about the green active state. I think the blue works better. Maybe the extension needs some changing to make it green when the code overview is not visible and blue when it is (which would probably follow the guidelines better).

![new color](https://cloud.githubusercontent.com/assets/3382464/3155219/806d2714-eabb-11e3-9aad-9f2a0441bb94.png)
