### PR TITLE
Add keywords for "minimap"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "brackets-codeoverview",
     "title": "CodeOverview",
     "description": "An easy to use overview of your editor's code.",
+    "keywords": [ "mini map", "minimap", "mini-map" ],
     "homepage": "https://github.com/thomasvalera/Brackets-CodeOverview",
     "version": "1.0.3",
     "author": "thomasvalera <thomasvalera@gmail.com> (https://github.com/thomasvalera)",


### PR DESCRIPTION
Add keywords so this extension shows up when users search Extension Manager for "minimap" (the name Sublime popularly uses for this feature).

You could also put one of these terms directly in the description, of course, but I wasn't sure if you'd want to change that.
