### PR TITLE
Fix zooming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+**May 12, 2015**
++ 1.0.4
+  + Minimap stays open when switching files
+  + Zoom set to 25% by default
+  + Slightly wider minimap
+  + Fixed Zooming

--- a/OverviewManager.js
+++ b/OverviewManager.js
@@ -1,23 +1,23 @@
 // ------------------------------------------------------------------------
 /*
  * Copyright (c) 2014 Thomas Valera. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  *
  */
@@ -35,29 +35,29 @@
 /*jslint nomen: true, vars: true */
 define(function (require, exports, module) {
     'use strict';
-    
+
     // Load modules
     var ViewManager     = require("OverviewViewManager"),
         EditorManger    = brackets.getModule("editor/EditorManager"),
         Editor          = brackets.getModule("editor/Editor"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
-        
+
         _overviewEditor = null;
-  
+
 // ------------------------------------------------------------------------
 /*
  *  HELPER FUNCTIONS
  */
-// ------------------------------------------------------------------------   
+// ------------------------------------------------------------------------
     /*
      * Returns the current full editor if exists,
      * null otherwise
      */
     function _getCurrentFullEditor() {
-        
+
         return EditorManger.getCurrentFullEditor();
     }
-    
+
     /*
      * Sets the listeners for the overviewEditor
      */
@@ -67,10 +67,10 @@ define(function (require, exports, module) {
             if (obj.target.getCursorPos().line !== _getCurrentFullEditor().getCursorPos().line) {
                 // Get new position
                 var cursorPos = _overviewEditor.getCursorPos();
-                
+
                 // Set cursor to selected line and center view to position
                 _getCurrentFullEditor().setCursorPos(cursorPos.line, cursorPos.ch, true, false);
-        
+
                 // Set timeout before giving focus back to master editor
                 // This fixes the bug where the overviewEditor still gets the final focus
                 // TODO: FIX THIS!
@@ -80,27 +80,27 @@ define(function (require, exports, module) {
             }
         });
     }
-    
+
     /*
      * Sets the given document and overview element in overviewEditor.
      * If document is null, destroy and disable overivew.
      */
     function _setOverviewEditorWithDocument(document, overview) {
-        
+
         // If document exists
         if (document !== null && overview !== undefined) {
-            
+
             // If overviewEdor does not exist or overvieweditor has different document
             if (_overviewEditor === null || document !== _overviewEditor.document) {
-                
+
                 // If overviewEditor exists, destroy
                 if (_overviewEditor !== null) {
                     _overviewEditor.destroy();
                 }
-                
+
                 // Create overview editor
                 _overviewEditor = new Editor.Editor(document, false, overview.find("#code-overview-content").get(0));
-                
+
                 // Set listeners
                 _setOverviewEditorListeners();
                 // Enable
@@ -108,8 +108,8 @@ define(function (require, exports, module) {
             }
         } else if (document === null) {
             // Destroy and disable
-            ViewManager.disable();
-            
+//            ViewManager.disable();
+
             // If overviewEditor exists
             if (_overviewEditor !== null) {
                 _overviewEditor.destroy();
@@ -119,19 +119,19 @@ define(function (require, exports, module) {
             console.error("Cannot set overview editor, document or overview do not exist");
         }
     }
-    
+
     /*
      * Reloads the overviewEditor if needed
      */
     function _reloadOverviewEditor() {
         // Get overview and fulleditor
         var overview = ViewManager.getOverview();
-        
+
         // If overview exists
         if (overview !== null && overview !== undefined) {
-            
+
             var fullEditor = _getCurrentFullEditor();
-            
+
             // If overview and fullEditor exist
             if (fullEditor !== null) {
                 _setOverviewEditorWithDocument(fullEditor.document, overview);
@@ -143,46 +143,46 @@ define(function (require, exports, module) {
             console.error("Overview element does not exist");
         }
     }
-    
+
 // ------------------------------------------------------------------------
 /*
  *  LISTENERS FUNCTIONS
  */
 // ------------------------------------------------------------------------
-    
+
     /*
      * Sets the listeners for the viewmanager
      */
     function _setViewManagerListeners() {
-        
+
         $(ViewManager).on("OverviewAttached", function () {
             // If currentFullEditor exists, enable
             if (_getCurrentFullEditor() !== null) {
                 ViewManager.enable();
             }
         });
-        
+
         $(ViewManager).on("ZoomApplied", function () {
             _overviewEditor.refresh();
         });
-        
+
         $(ViewManager).on("OverviewVisible", function () {
             _reloadOverviewEditor();
         });
-        
+
         $(ViewManager).on("OverviewHidden", function () {
             _overviewEditor.destroy();
             _overviewEditor = null;
         });
     }
-    
+
     /*
      * Sets listener for panel manager
      */
     function _setDocumentManagerListeners() {
-        
+
         $(DocumentManager).on("currentDocumentChange", function () {
-            
+
             // Reload only if overviewEditor exists
             // This will handle the case where a new editor is available
             // and the case where the last editor is removed
@@ -195,7 +195,7 @@ define(function (require, exports, module) {
             }
         });
     }
-    
+
 // ------------------------------------------------------------------------
 /*
  *  API FUNCTIONS
@@ -208,13 +208,12 @@ define(function (require, exports, module) {
         // Set listeners
         _setDocumentManagerListeners();
         _setViewManagerListeners();
-        
+
         // Initialize viewmanager
         ViewManager.init();
     }
-    
+
     // API
     exports.init = init;
 });
 
-    

--- a/OverviewViewManager.js
+++ b/OverviewViewManager.js
@@ -116,6 +116,9 @@ define(function (require, exports, module) {
         
         // Get Overview's CodeMirror wrapper
         var CMWrapper = content.find(".CodeMirror").first();
+
+        // Get overview's CodeMirror-scroll wrapper
+        var CMScroll = content.find(".CodeMirror-scroll").first();
         
         if (CMWrapper.length > 0) {
             // If first time zooming, use this chance to get the original values
@@ -128,9 +131,9 @@ define(function (require, exports, module) {
             var newFontSize = masterFontSize * zoom + "px",
                 newLineHeight = masterLineHeight * zoom + "px";
             
-            // Set properties to overview's CodeMirror
-            CMWrapper.get(0).style.setProperty("font-size", newFontSize, "!important");
-            CMWrapper.get(0).style.setProperty("line-height", newLineHeight, "!important");
+            // Set properties to overview's CodeMirror-scroll
+            CMScroll.css("font-size", newFontSize, "!important");
+            CMScroll.css("line-height", newLineHeight, "!important");
             
             _triggerEvent("ZoomApplied", {});
         }

--- a/OverviewViewManager.js
+++ b/OverviewViewManager.js
@@ -1,23 +1,23 @@
 // ------------------------------------------------------------------------
 /*
  * Copyright (c) 2014 Thomas Valera. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  *
  */
@@ -41,53 +41,53 @@
 /*jslint nomen: true, vars: true */
 define(function (require, exports, module) {
     'use strict';
-    
+
     var SimpleSlider            = require("plugins/simple-slider.min"),
-        
+
         _unrenderedOverview     = require("text!htmlContent/overview.html"),
         _unrenderedToolbarIcon  = require("text!htmlContent/toolbar.html"),
-    
+
         masterLineHeight        = null,
         masterFontSize          = null,
-        
+
         _renderedOverview       = null,
         _renderedToolbarIcon    = null,
-        
+
         slider                  = null,
-        zoom                    = 0.5;
-    
+        zoom                    = 0.25;
+
 // ------------------------------------------------------------------------
 /*
  *  HELPER FUNCTIONS
  */
-// ------------------------------------------------------------------------   
-    
+// ------------------------------------------------------------------------
+
     /*
      * Triggers the given event
      */
     function _triggerEvent(event, data) {
         $(exports).triggerHandler(event, data);
     }
-    
+
     /*
      * Returns the overview
      */
     function getOverview() {
         return $("#code-overview-wrapper");
     }
-    
+
     /*
      * Returns the toolbar icon
      */
     function _getToolbarIcon() {
         return $("#code-overview-icon");
     }
-    
+
 // ------------------------------------------------------------------------
 /*
  *  RENDER FUNCTIONS
  */
-// ------------------------------------------------------------------------  
+// ------------------------------------------------------------------------
     /*
      * Returns a rendered toolbar view
      */
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
         var view = $(Mustache.render(_unrenderedToolbarIcon));
         return view;
     }
-    
+
     /*
      * Returns a rendered overview view
      */
@@ -103,38 +103,38 @@ define(function (require, exports, module) {
         var view = $(Mustache.render(_unrenderedOverview));
         return view;
     }
-    
+
     /*
      * Sets the zoom
      */
     function _applyZoom() {
         // Get overview
         var overview = getOverview();
-        
+
         // Get overview content
         var content = overview.find("#code-overview-content");
-        
+
         // Get Overview's CodeMirror wrapper
         var CMWrapper = content.find(".CodeMirror").first();
 
         // Get overview's CodeMirror-scroll wrapper
         var CMScroll = content.find(".CodeMirror-scroll").first();
-        
+
         if (CMWrapper.length > 0) {
             // If first time zooming, use this chance to get the original values
             if (masterFontSize === null || masterLineHeight === null) {
                 masterFontSize = CMWrapper.css("font-size").replace("px", "");
                 masterLineHeight = CMWrapper.css("line-height").replace("px", "");
             }
-            
+
             // Apply zoom and add px to make usable string
             var newFontSize = masterFontSize * zoom + "px",
                 newLineHeight = masterLineHeight * zoom + "px";
-            
+
             // Set properties to overview's CodeMirror-scroll
             CMScroll.css("font-size", newFontSize, "!important");
             CMScroll.css("line-height", newLineHeight, "!important");
-            
+
             _triggerEvent("ZoomApplied", {});
         }
     }
@@ -147,37 +147,37 @@ define(function (require, exports, module) {
      * Sets the listeners for the slider
      */
     function _setSliderListeners() {
-    
+
         // Get overview
         var overview = getOverview();
-        
+
         // Get slider
         slider = overview.find("#code-overview-slider");
-        
+
         // Initialize slider
         slider.simpleSlider();
-        
+
         // Bind on change
         slider.bind("slider:changed", function (event, data) {
-          
+
             zoom = data.ratio;
             _applyZoom();
         });
-        
+
     }
-    
+
     /*
      * Sets the listeners for the toolbar icon
      */
     function _setToolbarIconListeners() {
-        
+
         // On click on icon
         $("#code-overview-icon").click(function () {
-            
+
             // Get overview and icon
             var overview = getOverview(),
                 icon = _getToolbarIcon();
-            
+
             if (overview !== null) {
                 // If visible, hide
                 if (overview.is(":visible")) {
@@ -185,17 +185,17 @@ define(function (require, exports, module) {
                     _triggerEvent("OverviewHidden", {});
                 } else if (icon.hasClass("enabled")) {
                     // Else if hidden and enabled
-                    
+
                     // Show overview and reload editors
-                    // NOTE: The order is important as the editor will 
+                    // NOTE: The order is important as the editor will
                     // only attach itself to a visible overview.
                     overview.show();
-                    
+
                     _triggerEvent("OverviewVisible", {});
-                    
+
                     // Set default zoom
                     slider.simpleSlider("setRatio", zoom);
-                    
+
                 }
             }
         });
@@ -211,35 +211,35 @@ define(function (require, exports, module) {
     function _attachOverview() {
         // Append overview to editor holder
         $("#editor-holder").append(_renderedOverview);
-        
+
         // Set width to overview
         getOverview().css("width", 200);
-        
+
         // Get width of main view
         var mainWidth = $(".main-view").first().width();
-        
+
         // Set width to overview's content
         // This will allow an overflow of the text instead of breaking
         // it and making spurious lines in the overview
         $("#code-overview-content").css("width", mainWidth);
-        
+
         // Set listeners
         _setSliderListeners();
-        
+
         // Listeners for the overview are really only the click listener.
         // This is done in the OverviewManager by listening to the editor's events
-        
+
         // Trigger event
         _triggerEvent("OverviewAttached", {});
     }
-    
+
     /*
      * Attaches the toolbar icon
      */
     function _attachToolbarIcon() {
         // Add toolbar after live icon
         $("#main-toolbar").find("#toolbar-go-live").after(_renderedToolbarIcon);
-        
+
         // Set listeners
         _setToolbarIconListeners();
     }
@@ -249,7 +249,7 @@ define(function (require, exports, module) {
  * API FUNCTIONS
  */
 // ------------------------------------------------------------------------
-    
+
     /*
      * Enables the overview
      */
@@ -259,59 +259,59 @@ define(function (require, exports, module) {
 
         // If disabled, enable
         if (icon.hasClass("disabled")) {
-            
+
             icon.removeClass("disabled");
             icon.addClass("enabled");
-            
+
         }
         _applyZoom();
     }
-    
+
     /*
      * Disables the overview.
      * Hides it if necessary
      */
-    function disable() {
-        // Get icon
-        var icon = _getToolbarIcon();
-        
-        // If enabled, disable
-        if (icon.hasClass("enabled")) {
-            
-            icon.removeClass("enabled");
-            icon.addClass("disabled");
-            
-            // Get overview
-            var overview = getOverview();
-            
-            if (overview !== null) {
-                // If visible, hide
-                if (overview.is(":visible")) {
-                    overview.hide();
-                }
-            }
-        }
-    }
-    
+//    function disable() {
+//        // Get icon
+//        var icon = _getToolbarIcon();
+//
+//        // If enabled, disable
+//        if (icon.hasClass("enabled")) {
+//
+//            icon.removeClass("enabled");
+//            icon.addClass("disabled");
+//
+//            // Get overview
+//            var overview = getOverview();
+//
+//            if (overview !== null) {
+//                // If visible, hide
+//                if (overview.is(":visible")) {
+//                    overview.hide();
+//                }
+//            }
+//        }
+//    }
+
     /*
      * Initializes the view manager.
      */
     function init() {
-        
+
         // Render views
         _renderedOverview = _renderOverview();
         _renderedToolbarIcon = _renderToolbarIcon();
-        
+
         // Display views
         _attachToolbarIcon();
         _attachOverview();
     }
-    
-    
-    
+
+
+
     // API
     exports.init = init;
     exports.enable = enable;
-    exports.disable = disable;
+//    exports.disable = disable;
     exports.getOverview = getOverview;
 });

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
+Brackets CodeOverview FORKED!
+===================
+
+Fixes and Features
+===================
++ Minimap stays open when switching files
++ Zoom set to 25% by default
++ Slightly wider minimap
++ Fixed Zooming
+
+Todo
+===================
++ Minimap is open by default
++ Minimap no longer overlaps code viewport
+
+(Original README.md below)
+
 Brackets CodeOverview
 ===================
 
-_Scroll up, scroll up, scroll up ... oh wait ... scrool down, scroll down ... hm I wish I didn't have to scroll so much to find the code I need!_  
+Scroll up, scroll up, scroll up ... oh wait ... scroll down, scroll down ... hm I wish I didn't have to scroll so much to find the code I need!_
 Well friend, wish no more because CodeOverview is here!
 With CodeOverview you will never have to scroll up and down hundreads of times before you find what you are looking for! Open the overview in 1 easy click, adapt the overview's zoom level to your convenience and you are ready to go and find what you need in the blink of an eye!
 
@@ -13,10 +30,10 @@ Due to lack of time, this extension will not see any updates anymore. If you lik
 Features
 ===================
 
-* Overview of your whole editor  
+* Overview of your whole editor
 ![CodeOverview](https://raw.github.com/thomasvalera/Brackets-CodeOverview/master/images/Brackets-CodeOverview-overview.png)
 
-* Customizable zoom  
+* Customizable zoom
 ![Zoom](https://raw.github.com/thomasvalera/Brackets-CodeOverview/master/images/Brackets-CodeOverview-zoom-big.png)
 
 How To
@@ -48,13 +65,13 @@ FAQ
 
 * The icon is red and doesn't work!
   - If the icon is red, this means you probably don't have any editor open! Open a file and it will work again!
-  
+
 * Does he know how awesome this extension is?
   - You tell me! Fork, contribute and keep this extension alive!
 
 * A bug?
   - Open an issue and I will try to fix it as quickly as possible!
-  
+
 Contact
 ===================
 If you want to contribute, ask some questions or even discuss possible features to add, open an _enhancement_ ticket or fork this repo!

--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,12 @@
+.pane-content {
+  width: calc(100% - 256px);
+}
+
+
+
+
+
+
 .co-icon {
     font-size: 20px;
 }
@@ -19,10 +28,9 @@
     top: 0;
     right: 0;
     height: 100%;
-    width: 200px;
     z-index: 10000000;
     overflow: hidden;
-    min-width: 100px;
+    min-width: 256px;
 /*    margin-right: 20px;*/
     display: none;
 }
@@ -77,7 +85,7 @@
 }
 
 .code-overview-wrapper .slider {
-    width: 140px !important;
+    width: 196px !important;
     float:left;
     height: 100%;
     margin-left: 10px !important;


### PR DESCRIPTION
Closes #8 and #9

Brackets has an important flag on the font size on `.Codemirror` that can only be overridden with inline CSS. This pull request adds the zoomed font size changes inline onto `.Codemirror-scroll` instead.
